### PR TITLE
Fix descriptions in Swagger UI

### DIFF
--- a/src/API/TradeTracker.Api/Controllers/AccountController.cs
+++ b/src/API/TradeTracker.Api/Controllers/AccountController.cs
@@ -30,16 +30,16 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="authenticationRequest">Authentication request containing account information</param>
         /// <returns>An ActionResult of type AuthenticationResponse</returns>
-        /// <example>
-        /// <code>
-        /// POST /api/account/authenticate 
+        /// <remarks>
+        /// Example:
         ///
-        /// { 
-        ///     "email": "yourEmail@yourEmail.com", 
-        ///     "password": "yourPassword!1" 
-        /// } 
-        /// </code>
-        /// </example>
+        ///     POST /api/account/authenticate 
+        ///     { 
+        ///         "email": "yourEmail@yourEmail.com", 
+        ///         "password": "yourPassword!1" 
+        ///     } 
+        ///
+        /// </remarks>
         /// <response code="422">Validation Error</response>
         [HttpPost("authenticate", Name="Authenticate")]
         [Consumes("application/json")]
@@ -60,11 +60,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/account/authenticate URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/account/authenticate 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/account/authenticate
+        ///
+        /// </remarks>
         [HttpOptions("authenticate", Name="OptionsForAuthenticate")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForAuthenticate()
@@ -82,18 +83,19 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="registrationRequest">Registration request containing account information</param>
         /// <returns>An ActionResult of type RegistrationResponse</returns>
-        /// <example>
-        /// <code>
-        /// POST /api/account/register 
-        /// { 
-        ///     "firstName": "yourFirstName", 
-        ///     "lastName" : "yourLastName", 
-        ///     "email": "yourEmail@yourEmail.com", 
-        ///     "userName": "yourUserName", 
-        ///     "password": "yourPassword!1" 
-        /// } 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     POST /api/account/register 
+        ///     { 
+        ///        "firstName": "yourFirstName", 
+        ///        "lastName" : "yourLastName", 
+        ///        "email": "yourEmail@yourEmail.com", 
+        ///        "userName": "yourUserName", 
+        ///        "password": "yourPassword!1" 
+        ///     }
+        /// 
+        /// </remarks>
         /// <response code="422">Validation Error</response>
         [HttpPost("register", Name="Register")]
         [Consumes("application/json")]
@@ -114,11 +116,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/account/register URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/account/register 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/account/register 
+        ///
+        /// </remarks>
         [HttpOptions("register", Name="OptionsForRegister")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForRegister()

--- a/src/API/TradeTracker.Api/Controllers/PositionsController.cs
+++ b/src/API/TradeTracker.Api/Controllers/PositionsController.cs
@@ -48,23 +48,23 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="query">The resource parameters for specifying the returned positions</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code> 
-        /// GET /api/positions 
+        /// <remarks>
+        /// Example:
         ///
-        /// { 
-        ///     "orderBy": "Quantity", 
-        ///     "pageNumber": "3", 
-        ///     "pageSize": "25", 
-        ///     "excluding": [ 
-        ///         "QRS", 
-        ///         "TUV", 
-        ///         "WXY" 
-        ///     ],
-        ///     "Exposure": "Long",
-        /// }
-        /// </code>
-        /// </example>
+        ///     GET /api/positions 
+        ///     { 
+        ///         "orderBy": "Quantity", 
+        ///         "pageNumber": "3", 
+        ///         "pageSize": "25", 
+        ///         "excluding": [ 
+        ///             "QRS", 
+        ///             "TUV", 
+        ///             "WXY" 
+        ///         ],
+        ///         "Exposure": "Long",
+        ///     }
+        ///
+        /// </remarks>
         /// <response code="200">Returns any paged positions matching the parameters</response>
         /// <response code="422">Validation Error</response>
         [HttpGet(Name = "GetPositions")]
@@ -140,11 +140,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/positions URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/positions 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/positions
+        ///
+        /// </remarks>
         [HttpOptions(Name = "OptionsForPositions")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForPositions()
@@ -162,11 +163,12 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="symbol">The symbol for the position</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code>
-        /// GET /api/positions/{symbol} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     GET /api/positions/{symbol}
+        ///
+        /// </remarks>
         /// <response code="200">Returns the requested position</response>
         /// <response code="422">Validation Error</response>
         [HttpGet("{symbol}", Name = "GetPosition")]
@@ -182,7 +184,7 @@ namespace TradeTracker.Api.Controllers
             "application/vnd.trade.position+json",
             "application/vnd.trade.position.hateoas+json",
             "application/vnd.trade.detailedposition.hateoas+json")]
-        public async Task<ActionResult<PositionForReturn>> GetPosition(
+        public async Task<IActionResult> GetPosition(
             [FromRoute] string symbol,
             [FromHeader(Name = "Accept")] string mediaType)
         {
@@ -254,11 +256,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/positions/{symbol} URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/positions/{symbol} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/positions/{symbol}
+        ///
+        /// </remarks>
         [HttpOptions("{symbol}", Name = "OptionsForPositionBySymbol")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForPositionBySymbol()

--- a/src/API/TradeTracker.Api/Controllers/TransactionCollectionsController.cs
+++ b/src/API/TradeTracker.Api/Controllers/TransactionCollectionsController.cs
@@ -47,30 +47,30 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="command">The transactions to be created</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code>
-        /// POST /api/transactioncollections 
+        /// <remarks>
+        /// Example:
         ///
-        /// [ 
-        ///     { 
-        ///         "dateTime": "2019-06-01T12:00:00", 
-        ///         "symbol": "XYZ" 
-        ///         "type": "SellToOpen", 
-        ///         "quantity": "1", 
-        ///         "notional": "50", 
-        ///         "tradePrice": "50" 
-        ///     }, 
-        ///     { 
-        ///         "dateTime": "2019-06-15T12:00:00", 
-        ///         "symbol": "XYZ" 
-        ///         "type": "BuyToClose", 
-        ///         "quantity": "1", 
-        ///         "notional": "40", 
-        ///         "tradePrice": "40" 
-        ///     }, 
-        /// ] 
-        /// </code>
-        /// </example>
+        ///     POST /api/transactioncollections 
+        ///     [ 
+        ///         { 
+        ///             "dateTime": "2019-06-01T12:00:00", 
+        ///             "symbol": "XYZ" 
+        ///             "type": "SellToOpen", 
+        ///             "quantity": "1", 
+        ///             "notional": "50", 
+        ///             "tradePrice": "50" 
+        ///         }, 
+        ///         { 
+        ///             "dateTime": "2019-06-15T12:00:00", 
+        ///             "symbol": "XYZ" 
+        ///             "type": "BuyToClose", 
+        ///             "quantity": "1", 
+        ///             "notional": "40", 
+        ///             "tradePrice": "40" 
+        ///         }, 
+        ///     ]
+        ///
+        /// </remarks>
         /// <response code="422">Validation Error</response>
         [HttpPost(Name = "CreateTransactionCollection")]
         [Consumes("application/json")]
@@ -146,11 +146,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/transactioncollections URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/transactioncollections 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/transactioncollections
+        ///
+        /// </remarks>
         [HttpOptions(Name = "OptionsForTransactionCollections")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForTransactionCollections()
@@ -168,11 +169,12 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="ids">The ids for the transactions</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code>
-        /// GET /api/transactioncollections/{firstId},{secondId} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     GET /api/transactioncollections/{firstId},{secondId}
+        /// 
+        /// </remarks>
         /// <response code="200">Returns the requested transactions</response>
         [EntityTagFilter]
         [HttpGet("{ids}", Name = "GetTransactionCollection")]
@@ -229,11 +231,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/transactioncollections/{transactionIds} URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/transactioncollections/{firstId},{secondId} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/transactioncollections/{firstId},{secondId} 
+        ///
+        /// </remarks>
         [HttpOptions("{ids}", Name = "OptionsForTransactionCollectionByIds")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForTransactionCollectionByIds()

--- a/src/API/TradeTracker.Api/Controllers/TransactionsController.cs
+++ b/src/API/TradeTracker.Api/Controllers/TransactionsController.cs
@@ -54,24 +54,24 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="query">The resource parameters for specifying the returned transactions</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code>
-        /// GET /api/transactions
+        /// <remarks>
+        /// Example:
         ///
-        /// { 
-        ///     "orderBy": "DateTime", 
-        ///     "pageNumber": "2" 
-        ///     "pageSize": "50", 
-        ///     "including": [ 
-        ///         "ABC", 
-        ///         "XYZ", 
-        ///         "MNO" 
-        ///     ], 
-        ///     "rangeStart": "2020-06-01T00:00:00", 
-        ///     "rangeEnd": "2021-01-01T00:00:00" 
-        /// } 
-        /// </code>
-        /// </example>
+        ///     GET /api/transactions
+        ///     { 
+        ///         "orderBy": "DateTime", 
+        ///         "pageNumber": "2" 
+        ///         "pageSize": "50", 
+        ///         "including": [ 
+        ///             "ABC", 
+        ///             "XYZ", 
+        ///             "MNO" 
+        ///         ], 
+        ///         "rangeStart": "2020-06-01T00:00:00", 
+        ///         "rangeEnd": "2021-01-01T00:00:00" 
+        ///     } 
+        /// 
+        /// </remarks>
         /// <response code="200">Returns any paged transactions matching parameters</response>
         /// <response code="422">Validation Error</response>
         [HttpGet(Name = "GetPagedTransactions")]
@@ -148,20 +148,20 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="command">The transaction to be created</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code>
-        /// POST /api/transactions 
+        /// <remarks>
+        /// Example:
         ///
-        /// { 
-        ///     "dateTime": "2020-01-01T12:30:15", 
-        ///     "symbol": "ABC" 
-        ///     "type": "BuyToOpen", 
-        ///     "quantity": "2.5", 
-        ///     "notional": "13.75", 
-        ///     "tradePrice": "5.50" 
-        /// } 
-        /// </code>
-        /// </example>
+        ///     POST /api/transactions 
+        ///     { 
+        ///         "dateTime": "2020-01-01T12:30:15", 
+        ///         "symbol": "ABC" 
+        ///         "type": "BuyToOpen", 
+        ///         "quantity": "2.5", 
+        ///         "notional": "13.75", 
+        ///         "tradePrice": "5.50" 
+        ///     }
+        ///
+        /// </remarks>
         /// <response code="422">Validation Error</response>
         [HttpPost(Name = "CreateTransaction")]
         [Consumes("application/json")]
@@ -213,11 +213,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/transactions URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/transactions 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/transactions 
+        /// 
+        /// </remarks>
         [HttpOptions(Name = "OptionsForTransactions")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForTransactions()
@@ -234,11 +235,11 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="id">The id of the transaction</param>
         /// <param name="mediaType">The request media type specified in the Accept header.</param>
-        /// <example>
-        /// <code>
-        /// GET /api/transactions/{id} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// 
+        ///     GET /api/transactions/{id} 
+        ///
+        /// </remarks>
         /// <response code="200">Returns the requested transaction</response>
         [HttpGet("{id}", Name = "GetTransaction")]
         [EntityTagFilter]
@@ -286,20 +287,20 @@ namespace TradeTracker.Api.Controllers
         /// <param name="id">The id for the transaction to be updated</param>
         /// <param name="command">The transaction with updated values</param>
         /// <response code="422">Validation Error</response>
-        /// <example>
-        /// <code>
-        /// PUT /api/transactions/{id} 
+        /// <remarks>
+        /// Example:
         ///
-        /// { 
-        ///     "dateTime": "2020-01-15T15:00:00", 
-        ///     "symbol": "CBA",
-        ///     "type": "SellToClose", 
-        ///     "quantity": "1.0", 
-        ///     "notional": "12.50", 
-        ///     "tradePrice": "12.50" 
-        /// } 
-        /// </code>
-        /// </example>
+        ///     PUT /api/transactions/{id} 
+        ///     { 
+        ///         "dateTime": "2020-01-15T15:00:00", 
+        ///         "symbol": "CBA",
+        ///         "type": "SellToClose", 
+        ///         "quantity": "1.0", 
+        ///         "notional": "12.50", 
+        ///         "tradePrice": "12.50" 
+        ///     } 
+        ///
+        /// </remarks>
         [HttpPut("{id}", Name = "UpdateTransaction")]
         [Consumes("application/json")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -324,24 +325,24 @@ namespace TradeTracker.Api.Controllers
         /// </summary>
         /// <param name="id">The id for the transaction to be updated</param>
         /// <param name="patchDocument">The set of operations to be applied to the transaction</param>
-        /// <example>
-        /// <code>
-        /// PATCH /api/transactions/{id} 
+        /// <remarks>
+        /// Example:
         ///
-        /// [ 
-        ///     { 
-        ///         "op": "replace", 
-        ///         "path": "/quantity", 
-        ///         "value": "25" 
-        ///     }, 
-        ///     { 
-        ///         "op": "replace", 
-        ///         "path": "/notional",
-        ///         "value": "75" 
-        ///     } 
-        /// ]
-        /// </code>
-        /// </example>
+        ///     PATCH /api/transactions/{id} 
+        ///     [ 
+        ///         { 
+        ///             "op": "replace", 
+        ///             "path": "/quantity", 
+        ///             "value": "25" 
+        ///         }, 
+        ///         { 
+        ///             "op": "replace", 
+        ///             "path": "/notional",
+        ///             "value": "75" 
+        ///         } 
+        ///     ]
+        ///
+        /// </remarks>
         /// <response code="422">Validation Error</response>
         [HttpPatch("{id}", Name = "PatchTransaction")]
         [Consumes("application/json")]
@@ -370,11 +371,12 @@ namespace TradeTracker.Api.Controllers
         /// Delete a transaction.
         /// </summary>
         /// <param name="id">The id for the transaction to be deleted</param>
-        /// <example>
-        /// <code>
-        /// DELETE /api/transactions/{id} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     DELETE /api/transactions/{id} 
+        /// 
+        /// </remarks>
         [HttpDelete("{id}", Name = "DeleteTransaction")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -393,11 +395,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/transactions/{id} URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/transactions/{id} 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/transactions/{id} 
+        ///
+        /// </remarks>
         [HttpOptions("{id}", Name = "OptionsForTransactionById")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForTransactionById()
@@ -413,11 +416,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Get all transactions as a CSV file.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// GET /api/transactions/export 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     GET /api/transactions/export
+        /// 
+        /// </remarks>
         /// <response code="200"></response>
         [HttpGet("export", Name = "ExportTransactions")]
         [FileResultContentType("text/csv")]
@@ -439,11 +443,12 @@ namespace TradeTracker.Api.Controllers
         /// <summary>
         /// Options for /api/transactions/export URI.
         /// </summary>
-        /// <example>
-        /// <code>
-        /// OPTIONS /api/transactions/export 
-        /// </code>
-        /// </example>
+        /// <remarks>
+        /// Example:
+        ///
+        ///     OPTIONS /api/transactions/export 
+        /// 
+        /// </remarks>
         [HttpOptions("export", Name = "OptionsForExportTransactions")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         public IActionResult OptionsForExportTransactions()

--- a/src/API/TradeTracker.Api/Extensions/Startup/SwaggerExtensions.cs
+++ b/src/API/TradeTracker.Api/Extensions/Startup/SwaggerExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,12 +32,10 @@ namespace TradeTracker.Api.Extensions.Startup
                         }
                     });
 
-                    var xmlCommmentsFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlCommmentsFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
                 var xmlCommentsFullPath = Path.Combine(AppContext.BaseDirectory, xmlCommmentsFile);
 
-                options.IncludeXmlComments(xmlCommentsFullPath);
-
-                options.ResolveConflictingActions(apiDescriptions => apiDescriptions.First());
+                options.IncludeXmlComments(xmlCommentsFullPath, includeControllerXmlComments: true);
             });
 
             return services;


### PR DESCRIPTION
- Replace <example> and <code> XML tags for controller actions with <remarks> to correctly display descriptions and examples for endpoints in Swagger UI